### PR TITLE
Package card hover

### DIFF
--- a/styles/available-package.less
+++ b/styles/available-package.less
@@ -14,6 +14,7 @@
     border: 1px solid @base-border-color;
     background-color: lighten(@tool-panel-background-color, 8%);
     overflow: hidden;
+    cursor: pointer;
 
     &:hover {
       background-color: lighten(@tool-panel-background-color, 10%);

--- a/styles/available-package.less
+++ b/styles/available-package.less
@@ -15,6 +15,10 @@
     background-color: lighten(@tool-panel-background-color, 8%);
     overflow: hidden;
 
+    &:hover {
+      background-color: lighten(@tool-panel-background-color, 10%);
+    }
+
     &.disabled {
       background-color: lighten(@tool-panel-background-color, 5%);
       .body,
@@ -27,10 +31,6 @@
       &:hover {
         background-color: lighten(@tool-panel-background-color, 4%);
       }
-    }
-
-    &:hover {
-      background-color: lighten(@tool-panel-background-color, 5%);
     }
 
     &.col-lg-4 {

--- a/styles/available-package.less
+++ b/styles/available-package.less
@@ -18,6 +18,9 @@
     &:hover {
       background-color: lighten(@tool-panel-background-color, 10%);
     }
+    &:active {
+      background-color: lighten(@tool-panel-background-color, 8%);
+    }
 
     &.disabled {
       background-color: lighten(@tool-panel-background-color, 5%);

--- a/styles/available-package.less
+++ b/styles/available-package.less
@@ -27,10 +27,6 @@
       .stats {
         opacity: .5;
       }
-
-      &:hover {
-        background-color: lighten(@tool-panel-background-color, 4%);
-      }
     }
 
     &.col-lg-4 {


### PR DESCRIPTION
This PR is on top of #429 and if merged should add to that PR. It changes:

- Lighten on hover, instead of darken
- No hover for disabled packages
- Add a pointer cursor on the whole card