### PR TITLE
Remove hover styles in detail views

### DIFF
--- a/lib/package-detail-view.coffee
+++ b/lib/package-detail-view.coffee
@@ -20,7 +20,7 @@ class PackageDetailView extends View
   Subscriber.includeInto(this)
 
   @content: (pack, packageManager) ->
-    @div =>
+    @div class: 'package-detail', =>
       @ol outlet: 'breadcrumbContainer', class: 'native-key-bindings breadcrumb', tabindex: -1, =>
         @li =>
           @a outlet: 'breadcrumb'

--- a/styles/available-package.less
+++ b/styles/available-package.less
@@ -247,6 +247,18 @@
     // End copy-paste from atom.io
 
   }
+
+  // Remove hover styles if it's in a detail view
+  .package-detail .package-card {
+    cursor: auto;
+    &:hover {
+      background-color: lighten(@tool-panel-background-color, 8%);
+    }
+    &.disabled {
+      background-color: lighten(@tool-panel-background-color, 5%);
+    }
+  }
+
 }
 
 @-webkit-keyframes available-package-is-installing {


### PR DESCRIPTION
This PR

- adds a `package-detail` class
- removes the styling in details view